### PR TITLE
Migrate to BT.CPP v4, add ROS service server node, add plugin registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5.1) # version on Ubuntu Trusty
 project(behaviortree_ros)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -9,7 +9,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(ROS_DEPENDENCIES
     roscpp std_msgs
-    behaviortree_cpp_v3
+    behaviortree_cpp
     actionlib_msgs
     actionlib
     message_generation)

--- a/include/behaviortree_ros/bt_action_node.h
+++ b/include/behaviortree_ros/bt_action_node.h
@@ -16,8 +16,8 @@
 #ifndef BEHAVIOR_TREE_BT_ACTION_NODE_HPP_
 #define BEHAVIOR_TREE_BT_ACTION_NODE_HPP_
 
-#include <behaviortree_cpp_v3/action_node.h>
-#include <behaviortree_cpp_v3/bt_factory.h>
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
 #include <ros/ros.h>
 #include <actionlib/client/simple_action_client.h>
 

--- a/include/behaviortree_ros/bt_action_node.h
+++ b/include/behaviortree_ros/bt_action_node.h
@@ -59,14 +59,19 @@ public:
 
   virtual ~RosActionNode() = default;
 
-  /// These ports will be added automatically if this Node is
-  /// registered using RegisterRosAction<DeriveClass>()
-  static PortsList providedPorts()
+  static PortsList
+  providedBasicPorts(PortsList addition)
   {
-    return  {
-      InputPort<std::string>("server_name", "name of the Action Server"),
-      InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")
-      };
+    PortsList basic = {InputPort<std::string>("server_name", "name of the Action Server"),
+                       InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")};
+    basic.insert(addition.begin(), addition.end());
+    return basic;
+  }
+
+  static PortsList
+  providedPorts()
+  {
+    return providedBasicPorts({});
   }
 
   /// Method called when the Action makes a transition from IDLE to RUNNING.

--- a/include/behaviortree_ros/bt_param_node.h
+++ b/include/behaviortree_ros/bt_param_node.h
@@ -16,8 +16,8 @@
 #define BEHAVIOR_TREE_BT_PARAM_NODE_HPP_
 
 #include <ros/ros.h>
-#include <behaviortree_cpp_v3/action_node.h>
-#include <behaviortree_cpp_v3/bt_factory.h>
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
 
 
 namespace BT {

--- a/include/behaviortree_ros/bt_param_node.h
+++ b/include/behaviortree_ros/bt_param_node.h
@@ -40,14 +40,21 @@ public:
   RosParamNode() = delete;
   virtual ~RosParamNode() = default;
 
-  static PortsList providedPorts()
+  static PortsList
+  providedBasicPorts(PortsList addition)
   {
-    return
-    {
-      InputPort<std::string>("param_name", "name of the parameter on the Parameter Server"),
+    PortsList basic = {
+        InputPort<std::string>("param_name", "name of the parameter on the Parameter Server"),
     };
+    basic.insert(addition.begin(), addition.end());
+    return basic;
   }
 
+  static PortsList
+  providedPorts()
+  {
+    return providedBasicPorts({});
+  }
 };
 
 

--- a/include/behaviortree_ros/bt_service_client_node.h
+++ b/include/behaviortree_ros/bt_service_client_node.h
@@ -63,15 +63,17 @@ public:
   }
 
   /// User must implement this method.
-  virtual void sendRequest(RequestType& request) = 0;
+  virtual bool sendRequest(RequestType& request) = 0;
 
   /// Method (to be implemented by the user) to receive the reply.
   /// User can decide which NodeStatus it will return (SUCCESS or FAILURE).
   virtual NodeStatus onResponse( const ResponseType& rep) = 0;
 
-  enum FailureCause{
+  enum FailureCause
+  {
     MISSING_SERVER = 0,
-    FAILED_CALL = 1
+    FAILED_CALL = 1,
+    REQUEST_INVALID = 2,
   };
 
   /// Called when a service call failed. Can be overriden by the user.
@@ -106,7 +108,10 @@ protected:
     }
 
     typename ServiceT::Request request;
-    sendRequest(request);
+    if (!sendRequest(request))
+    {
+      return onFailedRequest(REQUEST_INVALID);
+    }
     bool received = service_client_.call( request, reply_ );
     if( !received )
     {

--- a/include/behaviortree_ros/bt_service_client_node.h
+++ b/include/behaviortree_ros/bt_service_client_node.h
@@ -47,14 +47,19 @@ public:
 
   virtual ~RosServiceClientNode() = default;
 
-  /// These ports will be added automatically if this Node is
-  /// registered using RegisterRosAction<DeriveClass>()
-  static PortsList providedPorts()
+  static PortsList
+  providedBasicPorts(PortsList addition)
   {
-    return  {
-      InputPort<std::string>("service_name", "name of the ROS service"),
-      InputPort<unsigned>("timeout", 100, "timeout to connect to server (milliseconds)")
-      };
+    PortsList basic = {InputPort<std::string>("service_name", "name of the ROS service"),
+                       InputPort<unsigned>("timeout", 100, "timeout to connect to server (milliseconds)")};
+    basic.insert(addition.begin(), addition.end());
+    return basic;
+  }
+
+  static PortsList
+  providedPorts()
+  {
+    return providedBasicPorts({});
   }
 
   /// User must implement this method.

--- a/include/behaviortree_ros/bt_service_client_node.h
+++ b/include/behaviortree_ros/bt_service_client_node.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BEHAVIOR_TREE_BT_SERVICE_NODE_HPP_
-#define BEHAVIOR_TREE_BT_SERVICE_NODE_HPP_
+#ifndef BEHAVIOR_TREE_BT_SERVICE_CLIENT_NODE_HPP_
+#define BEHAVIOR_TREE_BT_SERVICE_CLIENT_NODE_HPP_
 
 #include <behaviortree_cpp/action_node.h>
 #include <behaviortree_cpp/bt_factory.h>
@@ -25,26 +25,27 @@ namespace BT
 {
 
 /**
- * Base Action to implement a ROS Service
+ * Base Action to implement a ROS Service Client
  */
 template<class ServiceT>
-class RosServiceNode : public BT::SyncActionNode
+class RosServiceClientNode : public BT::SyncActionNode
 {
 protected:
-
-  RosServiceNode(ros::NodeHandle& nh, const std::string& name, const BT::NodeConfiguration & conf):
-   BT::SyncActionNode(name, conf), node_(nh) { }
+  RosServiceClientNode(ros::NodeHandle& nh, const std::string& name, const BT::NodeConfiguration& conf)
+    : BT::SyncActionNode(name, conf)
+    , node_(nh)
+  {
+  }
 
 public:
-
-  using BaseClass    = RosServiceNode<ServiceT>;
+  using BaseClass = RosServiceClientNode<ServiceT>;
   using ServiceType  = ServiceT;
   using RequestType  = typename ServiceT::Request;
   using ResponseType = typename ServiceT::Response;
 
-  RosServiceNode() = delete;
+  RosServiceClientNode() = delete;
 
-  virtual ~RosServiceNode() = default;
+  virtual ~RosServiceClientNode() = default;
 
   /// These ports will be added automatically if this Node is
   /// registered using RegisterRosAction<DeriveClass>()
@@ -113,10 +114,11 @@ protected:
 
 /// Method to register the service into a factory.
 /// It gives you the opportunity to set the ros::NodeHandle.
-template <class DerivedT> static
-  void RegisterRosService(BT::BehaviorTreeFactory& factory,
-                     const std::string& registration_ID,
-                     ros::NodeHandle& node_handle)
+template<class DerivedT>
+static void
+RegisterRosServiceClient(BT::BehaviorTreeFactory& factory,
+                         const std::string& registration_ID,
+                         ros::NodeHandle& node_handle)
 {
   NodeBuilder builder = [&node_handle](const std::string& name, const NodeConfiguration& config) {
     return std::make_unique<DerivedT>(node_handle, name, config );
@@ -126,7 +128,7 @@ template <class DerivedT> static
   manifest.type = getType<DerivedT>();
   manifest.ports = DerivedT::providedPorts();
   manifest.registration_ID = registration_ID;
-  const auto& basic_ports = RosServiceNode< typename DerivedT::ServiceType>::providedPorts();
+  const auto& basic_ports = RosServiceClientNode<typename DerivedT::ServiceType>::providedPorts();
   manifest.ports.insert( basic_ports.begin(), basic_ports.end() );
 
   factory.registerBuilder( manifest, builder );
@@ -135,4 +137,4 @@ template <class DerivedT> static
 
 }  // namespace BT
 
-#endif  // BEHAVIOR_TREE_BT_SERVICE_NODE_HPP_
+#endif // BEHAVIOR_TREE_BT_SERVICE_CLIENT_NODE_HPP_

--- a/include/behaviortree_ros/bt_service_node.h
+++ b/include/behaviortree_ros/bt_service_node.h
@@ -16,8 +16,8 @@
 #ifndef BEHAVIOR_TREE_BT_SERVICE_NODE_HPP_
 #define BEHAVIOR_TREE_BT_SERVICE_NODE_HPP_
 
-#include <behaviortree_cpp_v3/action_node.h>
-#include <behaviortree_cpp_v3/bt_factory.h>
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
 #include <ros/ros.h>
 #include <ros/service_client.h>
 

--- a/include/behaviortree_ros/bt_service_server_node.h
+++ b/include/behaviortree_ros/bt_service_server_node.h
@@ -1,7 +1,16 @@
-/*
- * Enway GmbH - All Rights reserved.
- * Proprietary & confidential.
- */
+// Copyright (c) 2023 Enway GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef BEHAVIOR_TREE_BT_SERVICE_SERVER_NODE_HPP_
 #define BEHAVIOR_TREE_BT_SERVICE_SERVER_NODE_HPP_

--- a/include/behaviortree_ros/bt_service_server_node.h
+++ b/include/behaviortree_ros/bt_service_server_node.h
@@ -48,10 +48,18 @@ public:
   virtual ~RosServiceServerNode() = default;
 
   static PortsList
+  providedBasicPorts(PortsList addition)
+  {
+    PortsList basic = {InputPort<std::string>("service_name", "name of the ROS service"),
+                       InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")};
+    basic.insert(addition.begin(), addition.end());
+    return basic;
+  }
+
+  static PortsList
   providedPorts()
   {
-    return {InputPort<std::string>("service_name", "name of the ROS service"),
-            InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")};
+    return providedBasicPorts({});
   }
 
   virtual bool serviceCallback(RequestType& request, ResponseType& response) = 0;

--- a/include/behaviortree_ros/bt_service_server_node.h
+++ b/include/behaviortree_ros/bt_service_server_node.h
@@ -1,0 +1,83 @@
+/*
+ * Enway GmbH - All Rights reserved.
+ * Proprietary & confidential.
+ */
+
+#ifndef BEHAVIOR_TREE_BT_SERVICE_SERVER_NODE_HPP_
+#define BEHAVIOR_TREE_BT_SERVICE_SERVER_NODE_HPP_
+
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
+#include <ros/ros.h>
+
+namespace BT
+{
+
+template<class ServiceT>
+class RosServiceServerNode : public BT::SyncActionNode
+{
+protected:
+  ros::NodeHandle node_;
+  ros::ServiceServer service_server_;
+
+  RosServiceServerNode(ros::NodeHandle& nh, const std::string& name, const BT::NodeConfiguration& conf)
+    : BT::SyncActionNode(name, conf)
+    , node_(nh)
+  {
+    if (service_server_ == nullptr)
+    {
+      std::string service_name = getInput<std::string>("service_name").value();
+      service_server_ = node_.advertiseService(service_name, &RosServiceServerNode::serviceCallback, this);
+    }
+  }
+
+  BT::NodeStatus node_status = BT::NodeStatus::FAILURE;
+  BT::NodeStatus
+  tick() override
+  {
+    return node_status;
+  }
+
+public:
+  using BaseClass = RosServiceServerNode<ServiceT>;
+  using ServiceType = ServiceT;
+  using RequestType = typename ServiceT::Request;
+  using ResponseType = typename ServiceT::Response;
+
+  RosServiceServerNode() = delete;
+  virtual ~RosServiceServerNode() = default;
+
+  static PortsList
+  providedPorts()
+  {
+    return {InputPort<std::string>("service_name", "name of the ROS service"),
+            InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")};
+  }
+
+  virtual bool serviceCallback(RequestType& request, ResponseType& response) = 0;
+};
+
+template<class DerivedT>
+static void
+RegisterRosServiceServer(BT::BehaviorTreeFactory& factory,
+                         const std::string& registration_ID,
+                         ros::NodeHandle& node_handle)
+{
+  NodeBuilder builder = [&node_handle](const std::string& name, const BT::NodeConfiguration& config)
+  {
+    return std::make_unique<DerivedT>(node_handle, name, config);
+  };
+
+  TreeNodeManifest manifest;
+  manifest.type = getType<DerivedT>();
+  manifest.ports = DerivedT::providedPorts();
+  manifest.registration_ID = registration_ID;
+  const auto& basic_ports = RosServiceServerNode<typename DerivedT::ServiceType>::providedPorts();
+  manifest.ports.insert(basic_ports.begin(), basic_ports.end());
+
+  factory.registerBuilder(manifest, builder);
+}
+
+} // namespace BT
+
+#endif // BEHAVIOR_TREE_BT_SERVICE_SERVER_NODE_HPP_

--- a/include/behaviortree_ros/bt_topic_pub_node.h
+++ b/include/behaviortree_ros/bt_topic_pub_node.h
@@ -16,8 +16,8 @@
 #define BEHAVIOR_TREE_BT_TOPIC_PUBLISHER_NODE_HPP_
 
 #include <ros/ros.h>
-#include <behaviortree_cpp_v3/action_node.h>
-#include <behaviortree_cpp_v3/bt_factory.h>
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
 
 
 namespace BT {

--- a/include/behaviortree_ros/bt_topic_pub_node.h
+++ b/include/behaviortree_ros/bt_topic_pub_node.h
@@ -50,15 +50,20 @@ public:
   RosTopicPublisherNode() = delete;
   virtual ~RosTopicPublisherNode() = default;
 
-  static PortsList providedPorts()
+  static PortsList
+  providedBasicPorts(PortsList addition)
   {
-    return
-    {
-      InputPort<std::string>("topic_name", "name of the ROS Topic"),
-      InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")
-    };
+    PortsList basic = {InputPort<std::string>("topic_name", "name of the ROS Topic"),
+                       InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")};
+    basic.insert(addition.begin(), addition.end());
+    return basic;
   }
 
+  static PortsList
+  providedPorts()
+  {
+    return providedBasicPorts({});
+  }
 };
 
 

--- a/include/behaviortree_ros/bt_topic_sub_node.h
+++ b/include/behaviortree_ros/bt_topic_sub_node.h
@@ -16,8 +16,8 @@
 #define BEHAVIOR_TREE_BT_TOPIC_SUBSCRIBER_NODE_HPP_
 
 #include <ros/ros.h>
-#include <behaviortree_cpp_v3/action_node.h>
-#include <behaviortree_cpp_v3/bt_factory.h>
+#include <behaviortree_cpp/action_node.h>
+#include <behaviortree_cpp/bt_factory.h>
 
 
 namespace BT {

--- a/include/behaviortree_ros/bt_topic_sub_node.h
+++ b/include/behaviortree_ros/bt_topic_sub_node.h
@@ -54,13 +54,19 @@ public:
   RosTopicSubscriberNode() = delete;
   virtual ~RosTopicSubscriberNode() = default;
 
-  static PortsList providedPorts()
+  static PortsList
+  providedBasicPorts(PortsList addition)
   {
-    return
-    {
-      InputPort<std::string>("topic_name", "name of the ROS Topic"),
-      InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")
-    };
+    PortsList basic = {InputPort<std::string>("topic_name", "name of the ROS Topic"),
+                       InputPort<unsigned>("timeout", 500, "timeout to connect (milliseconds)")};
+    basic.insert(addition.begin(), addition.end());
+    return basic;
+  }
+
+  static PortsList
+  providedPorts()
+  {
+    return providedBasicPorts({});
   }
 
   virtual void topicCallback(const typename TopicType::ConstPtr &message) = 0;

--- a/include/behaviortree_ros/loggers/rosout_logger.h
+++ b/include/behaviortree_ros/loggers/rosout_logger.h
@@ -1,7 +1,7 @@
 #ifndef BT_ROSOUT_LOGGER_H
 #define BT_ROSOUT_LOGGER_H
 
-#include <behaviortree_cpp_v3/loggers/abstract_logger.h>
+#include <behaviortree_cpp/loggers/abstract_logger.h>
 #include <ros/console.h>
 
 namespace BT

--- a/include/behaviortree_ros/register_ros_plugin.h
+++ b/include/behaviortree_ros/register_ros_plugin.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2023 Davide Faconti
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <ros/node_handle.h>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <behaviortree_cpp/utils/shared_library.h>
+
+#include <filesystem>
+
+// Use this macro to generate a plugin for:
+//
+// - BT::RosActionNode
+// - BT::RosServiceNode
+// - BT::RosServiceNode
+// - BT::RosTopicPubNode
+// - BT::RosTopicSubNode
+//
+// - First argument: type to register (name of the class)
+// - Second argument: string with the registration name
+//
+// Usage example:
+//   CreateRosNodePlugin(MyClassName, "MyClassName");
+
+#define CreateRosNodePlugin(TYPE, REGISTRATION_NAME)                                                                   \
+  BTCPP_EXPORT void BT_RegisterRosNodeFromPlugin(BT::BehaviorTreeFactory& factory, ros::NodeHandle& node_handle)       \
+  {                                                                                                                    \
+    BT::NodeBuilder builder = [&node_handle](const std::string& name, const BT::NodeConfiguration& config)             \
+    {                                                                                                                  \
+      return std::make_unique<TYPE>(node_handle, name, config);                                                        \
+    };                                                                                                                 \
+                                                                                                                       \
+    BT::TreeNodeManifest manifest;                                                                                     \
+    manifest.type = BT::getType<TYPE>();                                                                               \
+    manifest.ports = TYPE::providedPorts();                                                                            \
+    manifest.registration_ID = REGISTRATION_NAME;                                                                      \
+                                                                                                                       \
+    factory.registerBuilder(manifest, builder);                                                                        \
+  }
+
+/**
+ * @brief RegisterRosNode function used to load a plugin and register
+ * the containing Node definition.
+ *
+ * @param factory     the factory where the node should be registered.
+ * @param filepath    path to the plugin.
+ * @param node_handle node handleto pass to the instances of the Node.
+ */
+inline void
+RegisterRosNode(BT::BehaviorTreeFactory& factory, const std::filesystem::path& filepath, ros::NodeHandle& node_handle)
+{
+  BT::SharedLibrary loader(filepath);
+  typedef void (*Func)(BT::BehaviorTreeFactory&, ros::NodeHandle&);
+  auto func = (Func)loader.getSymbol("BT_RegisterRosNodeFromPlugin");
+  func(factory, node_handle);
+}

--- a/include/behaviortree_ros/register_ros_plugin.h
+++ b/include/behaviortree_ros/register_ros_plugin.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2023 Davide Faconti
+// Copyright (c) 2023 Enway GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/package.xml
+++ b/package.xml
@@ -13,13 +13,13 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>behaviortree_cpp_v3</build_depend>
+  <build_depend>behaviortree_cpp</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
-  
+
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>behaviortree_cpp_v3</run_depend>
+  <run_depend>behaviortree_cpp</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
 

--- a/test/test_bt.cpp
+++ b/test/test_bt.cpp
@@ -1,4 +1,4 @@
-#include <behaviortree_ros/bt_service_node.h>
+#include <behaviortree_ros/bt_service_client_node.h>
 #include <behaviortree_ros/bt_action_node.h>
 #include <ros/ros.h>
 #include <behaviortree_ros/AddTwoInts.h>
@@ -38,19 +38,19 @@ public:
 // http://wiki.ros.org/ROS/Tutorials/WritingServiceClient%28c%2B%2B%29
 //-------------------------------------------------------------
 
-class AddTwoIntsAction: public RosServiceNode<behaviortree_ros::AddTwoInts>
+class AddTwoIntsAction: public RosServiceClientNode<behaviortree_ros::AddTwoInts>
 {
 
 public:
   AddTwoIntsAction( ros::NodeHandle& handle, const std::string& node_name, const NodeConfiguration & conf):
-  RosServiceNode<behaviortree_ros::AddTwoInts>(handle, node_name, conf) {}
+  RosServiceClientNode<behaviortree_ros::AddTwoInts>(handle, node_name, conf) {}
 
   static PortsList providedPorts()
   {
-    return  {
+    return  providedBasicPorts({
       InputPort<int>("first_int"),
       InputPort<int>("second_int"),
-      OutputPort<int>("sum") };
+      OutputPort<int>("sum") });
   }
 
   void sendRequest(RequestType& request) override
@@ -75,7 +75,7 @@ public:
     }
   }
 
-  virtual NodeStatus onFailedRequest(RosServiceNode::FailureCause failure) override
+  virtual NodeStatus onFailedRequest(RosServiceClientNode::FailureCause failure) override
   {
     ROS_ERROR("AddTwoInts request failed %d", static_cast<int>(failure));
     return NodeStatus::FAILURE;
@@ -99,9 +99,9 @@ RosActionNode<behaviortree_ros::FibonacciAction>(handle, name, conf) {}
 
   static PortsList providedPorts()
   {
-    return  {
+    return  providedBasicPorts({
       InputPort<int>("order"),
-      OutputPort<int>("result") };
+      OutputPort<int>("result") });
   }
 
   bool sendGoal(GoalType& goal) override
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
   BehaviorTreeFactory factory;
 
   factory.registerNodeType<PrintValue>("PrintValue");
-  RegisterRosService<AddTwoIntsAction>(factory, "AddTwoInts", nh);
+  RegisterRosServiceClient<AddTwoIntsAction>(factory, "AddTwoInts", nh);
   RegisterRosAction<FibonacciServer>(factory, "Fibonacci", nh);
 
   auto tree = factory.createTreeFromText(xml_text);

--- a/test/test_bt.cpp
+++ b/test/test_bt.cpp
@@ -158,8 +158,8 @@ private:
 
   // Simple tree, used to execute once each action.
   static const char* xml_text = R"(
- <root >
-     <BehaviorTree>
+ <root BTCPP_format="4">
+     <BehaviorTree ID="MainTree">
         <Sequence>
             <AddTwoInts service_name = "add_two_ints"
                         first_int = "3" second_int = "4"
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
   while( ros::ok() && (status == NodeStatus::IDLE || status == NodeStatus::RUNNING))
   {
     ros::spinOnce();
-    status = tree.tickRoot();
+    status = tree.tickOnce();
     std::cout << status << std::endl;
     ros::Duration sleep_time(0.01);
     sleep_time.sleep();

--- a/test/test_bt.cpp
+++ b/test/test_bt.cpp
@@ -53,12 +53,15 @@ public:
       OutputPort<int>("sum") });
   }
 
-  void sendRequest(RequestType& request) override
+  bool
+  sendRequest(RequestType& request) override
   {
     getInput("first_int", request.a);
     getInput("second_int", request.b);
     expected_result_ = request.a + request.b;
     ROS_INFO("AddTwoInts: sending request");
+
+    return true;
   }
 
   NodeStatus onResponse(const ResponseType& rep) override


### PR DESCRIPTION
Changes:
- Migrate to BT.CPP v4
- Add `RosServiceServerNode`
  - Rename original ROS service node to `RosServiceClientNode`
- Add plugin registration with macro `RegisterRosNode`
  - Use `static PortsList providedBasicPorts(PortsList addition)` to add common ports, so that all base classes can share the same plugin macro