### PR TITLE
Fix RosoutLogger implementation/building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ generate_messages(
 
 catkin_package(
     INCLUDE_DIRS include
-    LIBRARIES
+    LIBRARIES ${PROJECT_NAME}
     CATKIN_DEPENDS ${ROS_DEPENDENCIES}
 )
 
@@ -54,10 +54,8 @@ include_directories( include ${catkin_INCLUDE_DIRS})
 ######################################################
 # LIBRARIES
 
-#header only for the time being
-
-#add_library(behaviortree_ros ... )
-#target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+add_library(${PROJECT_NAME} src/loggers/rosout_logger.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 ######################################################
 # TESTS
@@ -78,6 +76,12 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+install(TARGETS ${PROJECT_NAME}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
 
 ######################################################
 # EXAMPLES and TOOLS

--- a/include/behaviortree_ros/loggers/rosout_logger.h
+++ b/include/behaviortree_ros/loggers/rosout_logger.h
@@ -4,6 +4,8 @@
 #include <behaviortree_cpp/loggers/abstract_logger.h>
 #include <ros/console.h>
 
+#include <atomic>
+
 namespace BT
 {
 

--- a/src/loggers/rosout_logger.cpp
+++ b/src/loggers/rosout_logger.cpp
@@ -56,7 +56,7 @@ void RosoutLogger::callback(Duration timestamp, const TreeNode& node, NodeStatus
         ROS_INFO("[%s%s]: %s -> %s",  node_name.c_str(),
                   &whitespaces[std::min(ws_count, node_name.size())],
                   toStr(prev_status, true).c_str(),
-                  toStr(status, true).c_srt());
+                  toStr(status, true).c_str());
         break;
     }
 }


### PR DESCRIPTION
Previously the RosoutLogger wouldn't even be built correctly, this fixes it so it can be used for debugging.