### PR TITLE
Fix ROS action node

### DIFF
--- a/include/behaviortree_ros/bt_action_node.h
+++ b/include/behaviortree_ros/bt_action_node.h
@@ -105,7 +105,6 @@ public:
     {
       action_client_->cancelGoal();
     }
-    setStatus(NodeStatus::IDLE);
   }
 
 protected:


### PR DESCRIPTION
BehaviorTree.CPP doesn't allow setting node status to IDLE manually (anymore?). It seems just removing this line fixes this, resetting the node status is taken care of in some other place (e.g. like [here](https://github.com/enwaytech/BehaviorTree.CPP/blob/2c2efefde9df821fe0e30ac9b5b6a7f5e9c5b799/src/control_node.cpp#L38)).

Compare https://github.com/enwaytech/BehaviorTree.CPP/blob/2c2efefde9df821fe0e30ac9b5b6a7f5e9c5b799/src/tree_node.cpp#L155